### PR TITLE
Update to v2.0 API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 /auth.py
+/__pycache__/
+/venv/
+/local_tuya.csv
+/*.json

--- a/README.md
+++ b/README.md
@@ -33,9 +33,10 @@ Change to the project directory: `cd LocalTuyaKeyExtractor`
 Optional - deactivate the venv: `deactivate`
 
 ### Setup your Authentication details
-open `auth_template.py` in the editor of your choice 
-- Change "ACCESS_ID" to the Access ID/Client ID copied from your Tuya IoT Cloud project
-- Change "ACCESS_KEY" to the Access Secret/Client Secret copied from your Tuya IoT Cloud project
+open `auth_template.py` in the editor of your choice and open the [Tuya Developer Platform Project page](https://platform.tuya.com/cloud/basic) in a browserr
+- Change "ACCESS_ID" to the Access ID/Client ID copied from your Tuya IoT Cloud project 
+- Change "ACCESS_SECRET" to the Access Secret/Client Secret copied from your Tuya IoT Cloud project
+- Change "API_ENDPOINT" according to match Data Center listed for the Cloud project (if needed)
 
 Save the modified file as `auth.py`
 

--- a/TuyaKeys.py
+++ b/TuyaKeys.py
@@ -67,7 +67,7 @@ def get_local_keys(device_id):
         'name': result['name'],
         'product_id': result['product_id'],
         'product_name': result['product_name'],
-        'ns': factory_device['sn'],
+        'sn': factory_device['ns'],
         'sub': result['sub'],
         'time_zone': result['time_zone'],
         'uuid': result['uuid']

--- a/TuyaKeys.py
+++ b/TuyaKeys.py
@@ -28,12 +28,23 @@ def get_local_keys(device_id):
         print(f'Something went wrong with cloud/thing/{device_id}')
         return None
 
+    factory_device = { 'mac': 'NOT FOUND', 'sn': 'NOT FOUND' }
+    # Get RAW mac Address Data from Tuya API
+    try:
+        factory_data = openapi.get(f"/v1.0/devices/factory-infos", params=params)
+        factory_device = factory_data['result'][0]
+    except TypeError as tex:
+        print(f' {device_id} Something went wrong with /v1.0/devices/factory-infos {tex}')
+    except KeyError as kex:
+        print(f' {device_id} Something went wrong with /v1.0/devices/factory-infos {kex}')
+    except IndexError as iex:
+        print(f' {device_id} Something went wrong with /v1.0/devices/factory-infos {iex}')
+
     pin_data = ''
     try:
         pin_data = openapi.get(f'/v1.1/devices/{device_id}/specifications')['result']
     except KeyError:
         print(f"No Pin data for this device: {device_id}")
-
 
     with open(f'pinouts-{device_id}.json', 'w') as outfile:
         json.dump(pin_data, outfile, indent=4)
@@ -51,10 +62,12 @@ def get_local_keys(device_id):
         'lat': result['lat'],
         'local_key': result['local_key'],
         'lon': result['lon'],
+        'mac': factory_device['mac'],
         'model': result['model'],
         'name': result['name'],
         'product_id': result['product_id'],
         'product_name': result['product_name'],
+        'ns': factory_device['sn'],
         'sub': result['sub'],
         'time_zone': result['time_zone'],
         'uuid': result['uuid']
@@ -82,7 +95,6 @@ def get_local_keys(device_id):
         print(f" {device_id} Status KeyError {kex}")
 
     return output_data
-
 
 device_list = []
 

--- a/TuyaKeys.py
+++ b/TuyaKeys.py
@@ -7,11 +7,11 @@ import json
 import pandas as pd
 from tuya_connector import TuyaOpenAPI
 
-# Add your ACCESS_ID and ACCESS_KEY to auth_template.py and save it as auth.py
-from auth import ACCESS_ID, ACCESS_KEY, API_ENDPOINT
+# Add your ACCESS_ID and ACCESS_SECRET to auth_template.py and save it as auth.py
+from auth import ACCESS_ID, ACCESS_SECRET, API_ENDPOINT
 
 # Instantiate the Tuya API Session
-openapi = TuyaOpenAPI(API_ENDPOINT, ACCESS_ID, ACCESS_KEY)
+openapi = TuyaOpenAPI(API_ENDPOINT, ACCESS_ID, ACCESS_SECRET)
 openapi.connect()
 
 #Load input.CSV into a Dataframe

--- a/TuyaKeys.py
+++ b/TuyaKeys.py
@@ -52,26 +52,27 @@ def get_local_keys(device_id):
     result = data['result']
     output_data = {
         'device_id': device_id,
-        'bind_space_id': result['bind_space_id'],
-        'category': result['category'],
-        'custom_name': result['custom_name'],
-        'icon': result['icon'],
-        'id': result['id'],
-        'ip': result['ip'],
-        'is_online': result['is_online'],
-        'lat': result['lat'],
-        'local_key': result['local_key'],
-        'lon': result['lon'],
-        'mac': factory_device['mac'],
-        'model': result['model'],
-        'name': result['name'],
-        'product_id': result['product_id'],
-        'product_name': result['product_name'],
-        'sn': factory_device['ns'],
-        'sub': result['sub'],
-        'time_zone': result['time_zone'],
-        'uuid': result['uuid']
+        'bind_space_id': result.get('bind_space_id', ''),
+        'category': result.get('category'),
+        'custom_name': result.get('custom_name', ''),
+        'icon': result.get('icon', ''),
+        'id': result.get('id', ''),
+        'ip': result.get('ip', ''),
+        'is_online': result.get('is_online', ''),
+        'lat': result.get('lat', ''),
+        'local_key': result.get('local_key', ''),
+        'lon': result.get('lon', ''),
+        'mac': factory_device.get('mac',''),
+        'model': result.get('model', ''),
+        'name': result.get('name', ''),
+        'product_id': result.get('product_id', ''),
+        'product_name': result.get('product_name', ''),
+        'sn': factory_device.get('sn', ''),
+        'sub': result.get('sub', ''),
+        'time_zone': result.get('time_zone', ''),
+        'uuid': result.get('uuid', '')
     }
+
     try:
         for index, pin in enumerate(pin_data['functions']):
             output_data[f'Function {index} code'] = pin['code']

--- a/TuyaKeys.py
+++ b/TuyaKeys.py
@@ -8,11 +8,7 @@ import pandas as pd
 from tuya_connector import TuyaOpenAPI
 
 # Add your ACCESS_ID and ACCESS_KEY to auth_template.py and save it as auth.py
-from auth import ACCESS_ID, ACCESS_KEY
-
-## You MIGHT need to change this endpoint if your API Endpoint is on a Different Server, i.e. China
-
-API_ENDPOINT = "https://openapi.tuyaeu.com"
+from auth import ACCESS_ID, ACCESS_KEY, API_ENDPOINT
 
 # Instantiate the Tuya API Session
 openapi = TuyaOpenAPI(API_ENDPOINT, ACCESS_ID, ACCESS_KEY)

--- a/auth_template.py
+++ b/auth_template.py
@@ -1,8 +1,9 @@
 # Add your Cloud Project Credentials here
+# https://platform.tuya.com/cloud/basic is the Tuya Developer Platform Portal
 # save this file as auth.py
 
 ACCESS_ID = "<Copy your Access ID/Client ID from Tuya Portal Here>"
-ACCESS_KEY = "<Copy your Access Secret/Client Secret from Tuya portal Here>"
+ACCESS_SECRET = "<Copy your Access Secret/Client Secret from Tuya portal Here>"
 
 # List available at https://developer.tuya.com/en/docs/iot/api-request?id=Ka4a8uuo1j4t4
 # China Data Center	https://openapi.tuyacn.com

--- a/auth_template.py
+++ b/auth_template.py
@@ -3,3 +3,14 @@
 
 ACCESS_ID = "<Copy your Access ID/Client ID from Tuya Portal Here>"
 ACCESS_KEY = "<Copy your Access Secret/Client Secret from Tuya portal Here>"
+
+# List available at https://developer.tuya.com/en/docs/iot/api-request?id=Ka4a8uuo1j4t4
+# China Data Center	https://openapi.tuyacn.com
+# Western America Data Center	https://openapi.tuyaus.com
+# Eastern America Data Center	https://openapi-ueaz.tuyaus.com
+# Central Europe Data Center	https://openapi.tuyaeu.com
+# Western Europe Data Center	https://openapi-weaz.tuyaeu.com
+# India Data Center	https://openapi.tuyain.com
+
+# You  need to change this endpoint if your account is linked to a different data center than Central Europe
+API_ENDPOINT = "https://openapi.tuyaeu.com"


### PR DESCRIPTION
Cleaned up .gitignore to ignore build and run artifacts.
Moved the API_ENDPOINT to the AUTH file (since it follows the account) and added the API endpoint to the template.
Switch to the /v2.0/cloud/thing/{device_id} endpoint for more detail
Switch to the /v1.0/devices/factory-infos endpoint for S/N and MAC
Emit all the new details information including S/N and MAC from factory infos.
Added more exception handling to ensure we don't die on minor issues.

